### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NativeScript Fingerprint Authentication
 
 > Also works with Face ID on iPhone X 🚀
+> Requires Xcode 9+, iOS 11 SDK
 
 [![Build Status][build-status]][build-url]
 [![NPM version][npm-image]][npm-url]


### PR DESCRIPTION
I ran into the issue that I was using Xcode 8.3.2 and could not reliably detect Face ID since I did not have the latest SDK.  Therefore, the check for biometrics always threw an exception, and the result always just had the `any` property set to `false`.  Neither the `touch` nor the `face` properties were set. The exception had to do with `LABiometryTypeTouchID` being unresolved.

I updated the README.md file as a warning to unsuspecting developers such as I.  It would be better to at least fall back to the previous way of determining whether Touch ID was available if the latest SDK isn't available.