### PR TITLE
Use proper event handling for activity result on Android

### DIFF
--- a/src/fingerprint-auth.android.ts
+++ b/src/fingerprint-auth.android.ts
@@ -1,5 +1,6 @@
 import * as app from "tns-core-modules/application";
 import * as utils from "tns-core-modules/utils/utils";
+import { AndroidActivityResultEventData } from "tns-core-modules/application";
 import {
   BiometricIDAvailableResult, ERROR_CODES,
   FingerprintAuthApi,
@@ -142,9 +143,10 @@ export class FingerprintAuth implements FingerprintAuthApi {
           this.verifyWithCustomAndroidUI(resolve, reject, callback);
 
         } else {
-          this.getActivity().onActivityResult = (requestCode, resultCode, data) => {
-            if (requestCode === REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS) {
-              if (resultCode === android.app.Activity.RESULT_OK) { // OK = -1
+
+          const onActivityResult = (data: AndroidActivityResultEventData) => {
+            if (data.requestCode === REQUEST_CODE_CONFIRM_DEVICE_CREDENTIALS) {
+              if (data.resultCode === android.app.Activity.RESULT_OK) { // OK = -1
                 // the user has just authenticated via the ConfirmDeviceCredential activity
                 resolve();
               } else {
@@ -155,7 +157,10 @@ export class FingerprintAuth implements FingerprintAuthApi {
                 });
               }
             }
+            app.android.off(app.AndroidApplication.activityResultEvent, onActivityResult);
           };
+
+          app.android.on(app.AndroidApplication.activityResultEvent, onActivityResult);
 
           if (!this.keyguardManager) {
             reject({


### PR DESCRIPTION
We've realised that when using the fingerprint plugin in combination with different plugins on the latest Android 8 that it somehow interferes with the Intent handling. We were using the fingerprint plugin in combination with your barcode plugin and on Android 8 the barcode result was never returned because the `activityResult` event was never thrown. When I was digging in your code I've realised that for some reason you're not using the event handling to get the activityResult instead you're somehow overwriting the method on the main foreground activity. I guess this caused the event propagation to fail. It seems like using the event handling fixes that problem tough I can't really explain why this only happens on Android 8. 