### PR TITLE
Fix Travis OSX image name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
       language: node_js
       node_js: "10"
       jdk: oraclejdk8
-      script: cd ../demo && travis_wait travis_retry tns build ios --bundle
+      script: pod repo update && cd ../demo && travis_wait travis_retry tns build ios --bundle
     - language: android
       os: linux
       env:
@@ -72,4 +72,4 @@ matrix:
       node_js: "10"
       jdk: oraclejdk8
       script:
-        - cd ../demo && travis_wait travis_retry tns build ios
+        - pod repo update && cd ../demo && travis_wait travis_retry tns build ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
       os: osx
       env:
         - Webpack="iOS"
-      osx_image: xcode10.0
+      osx_image: xcode10
       language: node_js
       node_js: "10"
       jdk: oraclejdk8
@@ -67,7 +67,7 @@ matrix:
       env:
         - BuildiOS="12"
         - Xcode="10.0"
-      osx_image: xcode10.0
+      osx_image: xcode10
       language: node_js
       node_js: "10"
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,7 @@ matrix:
       language: node_js
       node_js: "10"
       jdk: oraclejdk8
-      before_install: pod repo update
-      script: cd ../demo && travis_wait travis_retry tns build ios --bundle
+      script: pod repo update && cd ../demo && travis_wait travis_retry tns build ios --bundle
     - language: android
       os: linux
       env:
@@ -72,6 +71,5 @@ matrix:
       language: node_js
       node_js: "10"
       jdk: oraclejdk8
-      before_install: pod repo update
       script:
-        - cd ../demo && travis_wait travis_retry tns build ios
+        - pod repo update && cd ../demo && travis_wait travis_retry tns build ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ matrix:
       language: node_js
       node_js: "10"
       jdk: oraclejdk8
-      script: pod repo update && cd ../demo && travis_wait travis_retry tns build ios --bundle
+      before_install: pod repo update
+      script: cd ../demo && travis_wait travis_retry tns build ios --bundle
     - language: android
       os: linux
       env:
@@ -71,5 +72,6 @@ matrix:
       language: node_js
       node_js: "10"
       jdk: oraclejdk8
+      before_install: pod repo update
       script:
-        - pod repo update && cd ../demo && travis_wait travis_retry tns build ios
+        - cd ../demo && travis_wait travis_retry tns build ios


### PR DESCRIPTION
This commit fixes the wrong name of _osx_image_ in order to establish the iOS build.