### PR TITLE
Enhance error handling

### DIFF
--- a/src/fingerprint-auth.android.ts
+++ b/src/fingerprint-auth.android.ts
@@ -32,7 +32,9 @@ export class FingerprintAuth implements FingerprintAuthApi {
 
         // The fingerprint API is only available from Android 6.0 (M, Api level 23)
         if (android.os.Build.VERSION.SDK_INT < 23) {
-          reject(`Your api version doesn't support fingerprint authentication`);
+          resolve({
+            any: false
+          });
           return;
         }
 
@@ -44,7 +46,9 @@ export class FingerprintAuth implements FingerprintAuthApi {
 
         if (!fingerprintManager || !fingerprintManager.isHardwareDetected()) {
           // Device doesn't support fingerprint authentication
-          reject(`Device doesn't support fingerprint authentication`);
+          resolve({
+            any: false
+          });
         } else if (!fingerprintManager.hasEnrolledFingerprints()) {
           // If the user has not enrolled any fingerprints, they still might have the device secure so we can fallback
           // to present the user with the swipe, password, pin device security screen regardless
@@ -58,9 +62,10 @@ export class FingerprintAuth implements FingerprintAuthApi {
             });
           } else {
             // User hasn't enrolled any fingerprints to authenticate with
-            reject(
-                `User hasn't enrolled any fingerprints to authenticate with`
-            );
+            reject({
+              code: ERROR_CODES.NOT_CONFIGURED,
+              message: `User hasn't enrolled any fingerprints to authenticate with`
+            });
           }
         } else {
           resolve({

--- a/src/fingerprint-auth.common.ts
+++ b/src/fingerprint-auth.common.ts
@@ -1,4 +1,5 @@
 export enum ERROR_CODES {
+  BIOMETRY_LOCKOUT = -8,
   PASSWORD_FALLBACK_SELECTED = -3, // historically this is what iOS uses, so using that as well
   DEVELOPER_ERROR = 10,
   NOT_AVAILABLE = 20,

--- a/src/fingerprint-auth.ios.ts
+++ b/src/fingerprint-auth.ios.ts
@@ -31,22 +31,24 @@ export class FingerprintAuth implements FingerprintAuthApi {
               code: ERROR_CODES.BIOMETRY_LOCKOUT,
               message: "Biometric lockout.",
             });
+            return;
           } else if (ex.error.code === LAError.BiometryNotEnrolled) {
             reject({
               code: ERROR_CODES.NOT_CONFIGURED,
               message: "No biometric authentication has been configured.",
             });
+            return;
           } else if (ex.error.code === LAError.BiometryNotAvailable) {
             resolve({
               any: false
             });
+            return;
           }
-        } else {
-          reject({
-            code: ERROR_CODES.UNEXPECTED_ERROR,
-            message: "Unexpected error",
-          });
         }
+        reject({
+          code: ERROR_CODES.UNEXPECTED_ERROR,
+          message: "Unexpected error",
+        });
         console.log(`fingerprint-auth.available: ${ex}`);
       }
     });


### PR DESCRIPTION
My biggest complaint with the plugin was that the error handling was inconsistent, causing my code to be all over the place: sometimes a string is thrown, sometimes nothing is thrown, and sometimes a native error is thrown. Not only that, but the BiometryLockout error code for iOS was being glossed over by the `available` function, causing my application to think biometric auth wasn't available (and thus should continue without auth) when in reality, biometric auth IS available (and my application should NOT continue until biometric auth can be met).